### PR TITLE
Fixed pathnames on POSIX systems

### DIFF
--- a/7Zipper.js
+++ b/7Zipper.js
@@ -1,12 +1,13 @@
 "use strict";
 let winston = require('winston'),
     Zip = require('node-7z');
+const path = require('path');
 
 module.exports = function (location) {
     winston.info('7Ziping your files, Please wait...');
 
     let zip = new Zip();
 
-    return zip.add(location + '\\npm-personalNumber.7z', location)
+    return zip.add(location + path.sep + 'npm-personalNumber.7z', location)
             .then(() => winston.info(`Finished ziping!\n7Zip is wating for you in ${location}`))
 };

--- a/npmApi.js
+++ b/npmApi.js
@@ -9,6 +9,7 @@ let Promise = require('bluebird'),
     validUrl = require('valid-url'),
     got = require('got'),
     nameUtils = require('./nameUtils');
+const path = require('path');
 
 module.exports = {
     getVersionsOf (name) {
@@ -93,7 +94,7 @@ module.exports = {
 
         return download
             .use(downloadStatus())
-            .dest(downloadDir + '\\' + name + "\\-\\")
+            .dest(downloadDir + path.sep + name + path.sep + "-" + path.sep)
             .runAsync();
     }
 };


### PR DESCRIPTION
Changed the path separator from `"\\\\"` to `path.sep`, to fix issues #6 and #8 .
See the [API reference docs](https://nodejs.org/api/path.html#path_path_sep) on how it works.